### PR TITLE
Improved regex. Fixed flawed replacement logic.

### DIFF
--- a/os2web_cpr_filter.module
+++ b/os2web_cpr_filter.module
@@ -60,24 +60,27 @@ function _os2web_cpr_filter_settings($form, &$form_state, $filter, $format, $def
  */
 function _os2web_cpr_filter_process($text, $filter) {
   // Finding matches
-  preg_match_all("/([0-9]{6})(-?)([0-9]{4})/", $text, $matches);
-  
+  // To prevent false positives, match must not be preceded by a digit.
+  // To prevent false positives, match must be followed by a word boundary.
+  // Will allow a separator character (whitespace|slash|dot|dash) between date-month and month-year part.
+  // Will allow a separation string (whitespace+slash|dot|dash+whitespace, or just whitespace) between date and serial part
+  preg_match_all("/(?<!\d)\d{2}([\s\/\.\-]?)\d{2}\\1\d{2}(?:\s{0,2}[\/\.-]\s{0,2}|\s{0,2})\d{4}\b/", $text, $matches);
+
   // Looping through matches and replacing them
   $replace = array();
+
   foreach (current($matches) as $value) {
-    // Modulus11 check
-    if (!$filter->settings['modulus11_check'] || $modulus11_result = _os2web_cpr_filter_modulus11($value)) {
-      $replace[$value] = $value;     	
-    }
+    // remove separator characaters (anything except digits)
+    $stripped_value = preg_replace('/[^\d]/','',$value);
     // Replacing all numbers containing a dash
-    else if ($filter->settings['replace_all_dash'] && strpos($value, '-') !== FALSE) {
+    if ($filter->settings['replace_all_dash'] && strpos($value, '-') !== FALSE) {
       $replace[$value] = $value;
     }
-    // Date check
-    else if ($filter->settings['date_check'] && isset($modulus11_result) && !$modulus11_result) {
-      if (_os2web_cpr_filter_date_check($value)) {
-        $replace[$value] = $value;
-      }
+    // Modulus11 and date check
+    else if((!$filter->settings['modulus11_check'] || _os2web_cpr_filter_modulus11($stripped_value))
+      && (!$filter->settings['date_check'] || _os2web_cpr_filter_date_check($stripped_value)) )
+    {
+    $replace[$value] = $value;  
     }
   }
 
@@ -96,7 +99,6 @@ function _os2web_cpr_filter_process($text, $filter) {
  * @return bool
  */
 function _os2web_cpr_filter_modulus11($number) {
-  $number = str_replace('-', '', $number);
   $factor = '432765432';
   $number_arr = str_split($number);
   $factor_arr = str_split($factor);
@@ -124,7 +126,6 @@ function _os2web_cpr_filter_modulus11($number) {
  * @return bool
  */
 function _os2web_cpr_filter_date_check($number) {
-  $number = str_replace('-', '', $number);
   $day = substr($number, 0, 2);
   $month = substr($number, 2, 2);
   $year = substr($number, 4, 2);


### PR DESCRIPTION
We had some problems with false positives. A link to a video (http://media.videotool.dk/?vn=260_2014021815250419561819634619) was replaced by (http://media.videotool.dk/?vn=260_2014021815XXXXXX-XXXX19634619).
The improved regex in this hotfix removes some false positives while also including more possible matches.

The replacement logic was flawed:
If mod11 setting is false in line 69 the expression will always evaluate to true and thus enter line 70. This will then make the text replacement and code will not continue to make the date check even if the module is configured to check for dates.

If mod 11 setting is true and the match is positively validated agains modulus11 in line 69, the expression will evaluate to true and enter line 70 and make the text replacement even if the module is configured to also check for date validation. Example match: 851248-1230. This number validates against modulus11, but not against the date check. If i have configured my module to check for both date and mod11 this number should not be replaced.

This hotfix changes the replacement logic:
If replace_all_dash setting is on, any match containing a dash will be replaced not taking any of the other settings into account.
Also the modulus11 check and date check now works in unison so that numbers like 851248-1230 are not replaced if both checks are on.
